### PR TITLE
sidebar responsiveness

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import logo from "@/src/assets/normal.png";
-import { Divider, IconButton } from "@mui/material";
 import Image from "next/image";
 import Link from "next/link";
 import NavItem from "./NavItem";
@@ -11,12 +10,34 @@ import usePath from "../hooks/usePathName";
 import { SidebarProvider, useSidebar } from "../contexts/SidebarContext";
 import { BiChevronLeft, BiChevronRight, BiPlus } from "react-icons/bi";
 import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
 
 const Sidebar = () => {
   const activePath = usePath();
   const router = useRouter();
 
   const { isOpen, close, open } = useSidebar();
+  const [isMobile, setIsMobile] = useState(false);
+
+  const decideDevice = () => {
+    if (typeof window !== "undefined") {
+      if (window.innerWidth < 768) {
+        close();
+        setIsMobile(true);
+      } else {
+        open();
+        setIsMobile(false);
+      }
+    }
+  };
+
+  useEffect(() => {
+    decideDevice();
+    window.addEventListener("resize", decideDevice);
+    return () => {
+      window.removeEventListener("resize", decideDevice);
+    };
+  }, []);
 
   const getActivePath = (href: string, activePath: string) => {
     if (href === "/dashboard" && activePath === "dashboard") return true;
@@ -31,16 +52,18 @@ const Sidebar = () => {
           isOpen ? "w-1/6 items-start" : "w-20 items-center"
         } flex p-4 flex-col space-y-4 duration-300 bg-white h-screen border-r border-tertiary-500`}
       >
-        <button
-          onClick={isOpen ? close : open}
-          className="absolute border border-tertiary-400 rounded-full shadow-md bg-white -right-4 top-16"
-        >
-          {isOpen ? (
-            <BiChevronLeft className="h-6 w-6" />
-          ) : (
-            <BiChevronRight className="h-6 w-6" />
-          )}
-        </button>
+        {!isMobile && (
+          <button
+            onClick={isOpen ? close : open}
+            className="absolute border border-tertiary-400 rounded-full shadow-md bg-white -right-4 top-16"
+          >
+            {isOpen ? (
+              <BiChevronLeft className="h-6 w-6" />
+            ) : (
+              <BiChevronRight className="h-6 w-6" />
+            )}
+          </button>
+        )}
 
         <div className="flex gap-x-2 px-2 items-center place-content-center">
           <Link href="/" className="font-semibold shrink-0">
@@ -51,7 +74,7 @@ const Sidebar = () => {
             />
           </Link>
           {isOpen && (
-            <Link href="/" className="font-semibold text-3xl mini">
+            <Link href="/" className="font-semibold text-lg lg:text-3xl mini">
               Mini.me
             </Link>
           )}
@@ -65,9 +88,9 @@ const Sidebar = () => {
           {isOpen && <p>Create link</p>}
         </MyButton>
 
-        <div className="bg-tertiary h-px rounded-md w-full mb-4 " />
+        <div className="bg-tertiary h-px rounded-md w-full mb-6 lg:mb-4" />
 
-        <div className="flex flex-col w-full gap-y-4">
+        <div className="flex flex-col w-full gap-y-6 lg:gap-y-4">
           {PATHNAMES.map((pathname, index) => (
             <NavItem
               key={index}


### PR DESCRIPTION
This pull request includes several changes to the `Sidebar` component to improve its responsiveness and user experience on different devices. The most important changes include adding device detection logic, modifying the sidebar's behavior based on the device type, and updating the styling for different screen sizes.

Enhancements to device responsiveness:

* [`src/components/Sidebar.tsx`](diffhunk://#diff-5f3a5cc0c274c553bf7e5a260f594f138c16fd5197e1555cb608f862f0120f1cR13-R40): Added `useEffect` and `useState` hooks to manage the device type and adjust the sidebar's state accordingly. This includes the `decideDevice` function to determine if the device is mobile and update the sidebar's state.

Modifications to sidebar behavior:

* [`src/components/Sidebar.tsx`](diffhunk://#diff-5f3a5cc0c274c553bf7e5a260f594f138c16fd5197e1555cb608f862f0120f1cR55): Updated the sidebar toggle button to only be visible on non-mobile devices by wrapping it in a conditional check for `!isMobile`. [[1]](diffhunk://#diff-5f3a5cc0c274c553bf7e5a260f594f138c16fd5197e1555cb608f862f0120f1cR55) [[2]](diffhunk://#diff-5f3a5cc0c274c553bf7e5a260f594f138c16fd5197e1555cb608f862f0120f1cR66)
* [`src/components/Sidebar.tsx`](diffhunk://#diff-5f3a5cc0c274c553bf7e5a260f594f138c16fd5197e1555cb608f862f0120f1cL54-R77): Adjusted the link text size to be responsive, using `text-lg` for smaller screens and `text-3xl` for larger screens.

Styling updates for different screen sizes:

* [`src/components/Sidebar.tsx`](diffhunk://#diff-5f3a5cc0c274c553bf7e5a260f594f138c16fd5197e1555cb608f862f0120f1cL68-R93): Updated the margin-bottom of the divider and the gap between navigation items to be responsive, using larger values for smaller screens.

Additionally, an unused import statement was removed for cleaner code:

* [`src/components/Sidebar.tsx`](diffhunk://#diff-5f3a5cc0c274c553bf7e5a260f594f138c16fd5197e1555cb608f862f0120f1cL4): Removed the unused `Divider` and `IconButton` imports from `@mui/material`.